### PR TITLE
feat: メモ作成画面、ログイン状態で表示内容を変更する仕組み、テスト用の仮ユーザーの実装

### DIFF
--- a/sdb-memo-app/laravel/resources/js/App.vue
+++ b/sdb-memo-app/laravel/resources/js/App.vue
@@ -1,24 +1,34 @@
 <template>
     <div>
         <Header :is-loggedIn="isLoggedIn" :user-name="userName" />
-        <main class="p-4">
-            <router-view />
+        <main class="flex-1 overflow-y-auto">
+            <template v-if="isLoggedIn">
+                <router-view />
+            </template>
+            <template v-else>
+                <div class="text-center p-8">
+                    <h2 class="text-xl text-secondary-900 mb-4">
+                        ログインが必要です
+                    </h2>
+                    <p class="text-secondary-700">
+                        メモ機能を利用するには、ログインしてください。
+                    </p>
+                </div>
+            </template>
         </main>
     </div>
 </template>
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
 import Header from './components/Header.vue';
 
-const isLoggedIn = ref(false);
-const userName = ref('');
-
-onMounted(() => {
-//  ユーザーのログイン状態とユーザー名をバックエンドから取得する
-    const auth = document.querySelector('body[data-auth]')?.getAttribute('data-auth');
-    if (auth) {
-        isLoggedIn.value = true;
-        userName.value = '山田太郎'; //ダミーのユーザー名
+const props = defineProps({
+    isLoggedIn: {
+        type: Boolean,
+        required: true,
+    },
+    userName: {
+        type: String,
+        default: '',
     }
-})
+});
 </script>

--- a/sdb-memo-app/laravel/resources/js/app.ts
+++ b/sdb-memo-app/laravel/resources/js/app.ts
@@ -4,7 +4,10 @@ import App from "./App.vue";
 import pinia from "./plugins/pinia";
 import router from "./router";
 
-const app = createApp(App);
+const isLoggedIn = document.body.dataset.isLoggedIn === "true";
+const userName = document.body.dataset.userName || '';
+
+const app = createApp(App, { isLoggedIn, userName });
 app.use(pinia);
 app.use(router);
 app.mount("#app");

--- a/sdb-memo-app/laravel/resources/js/components/Button.vue
+++ b/sdb-memo-app/laravel/resources/js/components/Button.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+    defineProps({
+        disabled: {
+            type: Boolean,
+            default: true
+        }
+    });
+</script>
+
+<template>
+    <button
+        :disabled="disabled"
+        class="flex items-center justify-center rounded w-full space-x-2 py-3 px-4 transition-colors"
+        :class="disabled ? 'bg-gradient-to-r from-secondary-400 to-secondary-600 text-white cursor-not-allowed' : 'bg-gradient-to-r from-accent-600 to-primary-600 text-white'">
+        <span><slot></slot></span>
+    </button>
+</template>
+
+<style scoped>
+
+</style>

--- a/sdb-memo-app/laravel/resources/js/components/Header.vue
+++ b/sdb-memo-app/laravel/resources/js/components/Header.vue
@@ -13,7 +13,7 @@ const title = computed(() => {
 </script>
 
 <template>
-    <header class="p-4 flex flex-col items-center border-b border-secondary-200">
+    <header class="p-4 flex flex-col items-center border-b bg-white border-secondary-200">
         <div class="w-full flex justify-end mb-2">
             <nav>
                 <ul class="flex space-x-4">
@@ -38,8 +38,8 @@ const title = computed(() => {
         </div>
         <a href="/" class="text-center no-underline">
             <div class="flex items-center space-x-2">
-                <DocumentSvg class="w-8 h-8 text-accent-800" />
-                <h1 class="text-3xl font-thin text-accent-800">
+                <DocumentSvg class="w-8 h-8 text-accent-600" />
+                <h1 class="text-3xl font-light bg-gradient-to-r from-accent-600 to-primary-600 bg-clip-text text-transparent">
                     {{ title }}
                 </h1>
             </div>

--- a/sdb-memo-app/laravel/resources/js/components/TextareaForm.vue
+++ b/sdb-memo-app/laravel/resources/js/components/TextareaForm.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+    import { computed } from 'vue';
+
+    const props = defineProps({
+        modelValue: String,
+    });
+
+    const emits = defineEmits(['update:modelValue', 'saveMemo']);
+
+    const inputClass = computed(() => {
+        return props.modelValue
+    });
+
+    const handleInput = (e: Event) => {
+        emits('update:modelValue', (e.target as HTMLInputElement).value);
+    }
+
+    const handleEnter = (e: Event) => {
+        if (!e.shiftKey) {
+            emits('saveMemo');
+        } else {
+            emits('update:modelValue', (e.target as HTMLTextAreaElement).value + '\n');
+        }
+    };
+
+</script>
+
+<template>
+    <textarea
+        :value="modelValue"
+        @input="handleInput"
+        @keydown.enter.prevent="handleEnter"
+        class="appearance-none border rounded w-full py-2 px-3 text-secondary-700 leading-tight focus:outline-none focus:shadow-outline transition-colors border-secondary-300 focus:border-accent-800"
+        :class="inputClass"
+        rows="6"
+        placeholder="メモを入力してください…&#10;（Enterで保存、Shift+Enterで改行）"
+    ></textarea>
+</template>
+
+<style scoped>
+
+</style>

--- a/sdb-memo-app/laravel/resources/js/pages/index.vue
+++ b/sdb-memo-app/laravel/resources/js/pages/index.vue
@@ -1,7 +1,89 @@
 <script setup lang="ts">
-import Welcome from "../features/Welcome.vue";
+import { ref, computed, onMounted } from "vue";
+import PlusSvg from "../components/svgs/PlusSvg.vue";
+import TextareaForm from "../components/TextareaForm.vue";
+import Button from "../components/Button.vue";
+
+const memoTitle = ref('');
+const memoContent = ref('');
+const userId = ref<string | null>(null);
+
+onMounted(() => {
+    if (document.body.hasAttribute('data-user-id')) {
+        userId.value = document.body.getAttribute('data-user-id');
+    }
+});
+
+const isContentEntered = computed(() => {
+    return memoContent.value.length > 0;
+});
+
+const saveMemo = () => {
+    if (!isContentEntered.value) return;
+
+    let titleForAlert = '';
+    let contentForAlert = '';
+
+    // タイトル欄に入力がない場合、メモ内容の最初の行を見出しとして表示する。
+    if (memoTitle.value.length > 0) {
+        titleForAlert = `[${memoTitle.value}]`;
+        contentForAlert = memoContent.value;
+    } else {
+        const contentLines = memoContent.value.split('\n');
+        titleForAlert = `[${contentLines[0]}]`;
+        contentForAlert = memoContent.value;
+    }
+
+    alert(
+        `［保存されたメモ］\nタイトル: ${titleForAlert}\n内容: \n${contentForAlert}\n`
+    );
+    // 後にサーバーへ以下の情報を送り保存する
+    console.log({
+        user_id: userId.value,
+        title: memoTitle.value.length > 0 ? memoTitle.value : memoContent.value.split('\n')[0],
+        content: memoContent.value,
+    });
+
+    memoTitle.value = '';
+    memoContent.value = '';
+};
 </script>
 
 <template>
-  <Welcome />
+    <div class="p-4 md:p-8 flex justify-center items-start">
+        <div class="w-full max-w-lg bg-white p-6 rounded-lg shadow-lg">
+            <div class="flex items-center space-x-2 mb-6">
+                <PlusSvg class="w-6 h-6 text-accent-800" />
+                <h2 class="text-xl font-medium text-secondary-900">
+                    新しいメモ
+                </h2>
+            </div>
+
+            <form @submit.prevent="saveMemo">
+                <div class="mb-4">
+                    <label for="memoTitle" class="block text-secondary-700 text-sm font-medium mb-2">
+                        タイトル
+                    </label>
+                    <input
+                        id="memoTitle"
+                        type="text"
+                        v-model="memoTitle"
+                        class="appearance-none border rounded w-full py-2 px-3 text-secondary-700 leading-tight focus:outline-none focus:shadow-outline transition-colors border-secondary-300 focus:border-accent-800"
+                        placeholder="タイトルを入力してください…（空でも可）"
+                    />
+                </div>
+                <div class="mb-4">
+                    <label for="memoContent" class="block text-secondary-700 text-sm font-medium mb-2">
+                        内容
+                    </label>
+                    <TextareaForm v-model="memoContent" @saveMemo="saveMemo" />
+                </div>
+                <div class="flex justify-end">
+                    <Button type="submit" :disabled="!isContentEntered">
+                        + メモを保存
+                    </Button>
+                </div>
+            </form>
+        </div>
+    </div>
 </template>

--- a/sdb-memo-app/laravel/resources/views/app.blade.php
+++ b/sdb-memo-app/laravel/resources/views/app.blade.php
@@ -6,7 +6,12 @@
     <meta name="csrf-token" content="{{ csrf_token() }}">
     @vite(['resources/js/app.ts', 'resources/css/app.css'])
 </head>
-<body class="bg-secondary-50 text-secondary-900 font-sans font-light">
+<body
+    class="bg-primary-100 text-secondary-900 font-sans font-light"
+{{--    実際のコード--}}
+{{--    @auth data-user-id="{{ Auth::id() }}" data-user-name="{{ Auth::user()->name }}" data-is-logged-in="true" @endauth--}}
+{{--    @guest data-is-logged-in="false" @endguest--}}
+        data-user-id="999" data-user-name="テストユーザー" data-is-logged-in="true"> {{--ログイン後のテスト用の仮のコード--}}
     <div id="app"></div>
 </body>
 </html>


### PR DESCRIPTION
app.blade.php -> app.ts -> App.vueへとユーザーのログイン状態とユーザー名を渡すことでメインページで表示する内容を変える。
app.blade.php -> index.vueへとユーザーIDを渡すことで、メモの情報とユーザーIDを紐づけて後にmemosへと送れるようにした。