### PR TITLE
feat: 削除時のポップアップとCSSスタイルの改善

### DIFF
--- a/sdb-memo-app/laravel/resources/js/components/Button.vue
+++ b/sdb-memo-app/laravel/resources/js/components/Button.vue
@@ -2,7 +2,7 @@
     defineProps({
         disabled: {
             type: Boolean,
-            default: true
+            default: false
         }
     });
 </script>

--- a/sdb-memo-app/laravel/resources/js/components/Header.vue
+++ b/sdb-memo-app/laravel/resources/js/components/Header.vue
@@ -13,23 +13,23 @@ const title = computed(() => {
 </script>
 
 <template>
-    <header class="p-4 flex flex-col items-center border-b bg-white border-secondary-200 shadow-lg pb-6">
+    <header class="p-4 flex flex-col items-center border-b bg-white border-secondary-200 shadow-lg pb-6 transition-colors duration-300">
         <div class="w-full flex justify-end mb-2">
             <nav>
                 <ul class="flex space-x-4">
                     <template v-if="isLoggedIn">
-                        <li><a href="/history" class="inline-block text-secondary-500 border-r border-secondary-200 pr-4 hover:text-secondary-900 hover:scale-105 transition-all duration-300">
+                        <li><a href="/history" class="inline-block text-secondary-500 border-r border-secondary-200 pr-4 hover:text-secondary-900">
                             履歴
                         </a></li>
-                        <li><a href="/logout" class="inline-block text-secondary-500 hover:text-secondary-900 hover:scale-105 transition-all duration-300">
+                        <li><a href="/logout" class="inline-block text-secondary-500 hover:text-secondary-900">
                             ログアウト
                         </a></li>
                     </template>
                     <template v-else>
-                        <li><a href="/createUser" class="inline-block text-secondary-500 border-r border-secondary-200 pr-4 hover:text-secondary-900 hover:scale-105 transition-all duration-300">
+                        <li><a href="/createUser" class="inline-block text-secondary-500 border-r border-secondary-200 pr-4 hover:text-secondary-900">
                             新規登録
                         </a></li>
-                        <li><a href="/login" class="inline-block text-secondary-500 hover:text-secondary-900 hover:scale-105 transition-all duration-300">
+                        <li><a href="/login" class="inline-block text-secondary-500 hover:text-secondary-900">
                             ログイン
                         </a></li>
                     </template>
@@ -37,9 +37,9 @@ const title = computed(() => {
             </nav>
         </div>
         <a href="/" class="text-center no-underline">
-            <div class="flex items-center space-x-2 hover:hover:scale-105 transition-all duration-300">
-                <DocumentSvg class="w-8 h-8 text-accent-600" />
-                <h1 class="text-3xl font-light bg-gradient-to-r from-accent-600 to-primary-600 bg-clip-text text-transparent">
+            <div class="flex items-center space-x-2">
+                <DocumentSvg class="w-8 h-8 text-accent-600 hover:text-accent-800" />
+                <h1 class="text-3xl font-light bg-gradient-to-r from-accent-600 to-primary-600 hover:from-accent-800 hover:to-primary-800 bg-clip-text text-transparent">
                     {{ title }}
                 </h1>
             </div>

--- a/sdb-memo-app/laravel/resources/js/components/Modal.vue
+++ b/sdb-memo-app/laravel/resources/js/components/Modal.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+defineProps({
+    isOpen: {
+        type: Boolean,
+        default: true,
+    },
+});
+</script>
+
+<template>
+    <div v-if="isOpen" class="fixed inset-0 bg-secondary-900 bg-opacity-50 flex items-center justify-center z-50">
+        <div class="bg-white p-6 rounded-lg shadow-xl w-full max-w-sm">
+            <h3 class="text-lg font-semibold mb-4 text-secondary-900">
+                <slot name="header"></slot>
+            </h3>
+            <p class="text-secondary-700 mb-6">
+                <slot name="body"></slot>
+            </p>
+            <div class="flex justify-end space-x-4">
+                <slot name="footer"></slot>
+            </div>
+        </div>
+    </div>
+</template>
+
+<style scoped>
+
+</style>


### PR DESCRIPTION
CSSスタイルは文字単体の箇所のhoverの変更。
元はhover:scale-105で文字の大きさを変えていたが、それをなくし文字の色のみを変えるようにした。
ポップアップクラスは後に別のメッセージを表示させるのにも使えるように作成。